### PR TITLE
Keeps computation on appropriate devices

### DIFF
--- a/datamodules.py
+++ b/datamodules.py
@@ -203,9 +203,7 @@ class ConlluDataModule(pl.LightningDataModule):
             padding="longest",
             return_tensors="pt",
             is_split_into_words=True,
-        ).to(
-            "cuda" if torch.cuda.is_available() else "cpu"
-        )  # TODO this .to might really not be needed.
+        )
         if not tokenized_x.encodings:
             # for Byt5, which doesn't seem to have a fast tokenizer
             encodings_ = []
@@ -257,7 +255,7 @@ class ConlluDataModule(pl.LightningDataModule):
             padding="longest",
             return_tensors="pt",
             is_split_into_words=True,
-        ).to("cuda" if torch.cuda.is_available() else "cpu")
+        )
         return TextBatch(tokenized_x, sentences, replacements)
 
     def predict_dataloader(self):

--- a/udtube.py
+++ b/udtube.py
@@ -15,7 +15,7 @@ from torchmetrics.functional.classification import multiclass_accuracy
 
 from batch import ConlluBatch, TextBatch, CustomBatch
 from callbacks import CustomWriter
-from data_module import ConlluDataModule
+from datamodules import ConlluDataModule
 from typing import Union
 
 


### PR DESCRIPTION
Previously this would attempt to move the tokenizer to CUDA. This leads to a crash (see #13) if one requires a non-CUDA accelerator. Furthermore, apparently there is no real gain for tokenizing on GPU anyways: https://stackoverflow.com/a/66116061

Tested by attempting training on CPU with `accelerator: cpu` in the config file (previously a crash). I have taken the liberty of doing a cheeky rename too; I think this is more to style.

Closes #13.