### PR TITLE
Reads index from model_dir when appropriate

### DIFF
--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -70,7 +70,6 @@ class DataModule(lightning.LightningDataModule):
         use_feats: bool = defaults.USE_FEATS,
         # Other.
         batch_size: int = defaults.BATCH_SIZE,
-        index: Optional[indexes.Index] = None,
     ):
         super().__init__()
         self.train = train
@@ -83,8 +82,13 @@ class DataModule(lightning.LightningDataModule):
         self.use_lemma = use_lemma
         self.use_feats = use_feats
         self.batch_size = batch_size
-        # FIXME I need to be able to load the index from a file too.
-        self.index = index if index else self._make_index(model_dir)
+        # If the training data is specified, it is used to create (or recreate)
+        # the index; if not specified it is read from the model directory.
+        self.index = (
+            self._make_index(model_dir)
+            if self.train
+            else indexes.Index.read(model_dir)
+        )
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
             encoder, clean_up_tokenization_spaces=False
         )

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -33,7 +33,6 @@ class LemmaMapper:
         """Applies the lemma tag to a form."""
         rule = self.edit_script.fromtag(tag)
         return rule.apply(form.casefold())
-        return self.upos is not None
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
If `train` is not specified, the data module reads the index from `f{model_dir}/index.pkl`.

Closes #37.

Ideally, we'd instead tell the data module whether or not this is running in `fit` mode, but that seems to require a *lot* of additional plumbing so this seems like a good compromise.

This was tested by removing `train` argument during prediction; if `index.pkl` is moved to some other location, it then fails with a FileNotFound error as expected. 

I also fixed a drive-by in the mapper.