### PR TITLE
Enables persistent_workers.

### DIFF
--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -192,6 +192,7 @@ class DataModule(lightning.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=True,
             num_workers=1,
+            persistent_workers=True,
         )
 
     def val_dataloader(self) -> data.DataLoader:
@@ -205,6 +206,7 @@ class DataModule(lightning.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
+            persistent_workers=True,
         )
 
     def predict_dataloader(self) -> data.DataLoader:
@@ -219,6 +221,7 @@ class DataModule(lightning.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
+            persistent_workers=True,
         )
 
     def test_dataloader(self) -> data.DataLoader:
@@ -232,6 +235,7 @@ class DataModule(lightning.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
+            persistent_workers=True,
         )
 
     def _conllu_map_dataset(self, source: str) -> datasets.ConlluMapDataset:


### PR DESCRIPTION
When running on my Mac with MPS, the datamodule (which "has-a" Hugging Face) tokenizer spams the following recommendations:

```
/Users/kbg/.miniconda3/envs/udtube/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:419: Consider setting `persistent_workers=True` in 'val_dataloader' to speed up the dataloader worker initialization.
```

and so on for the train_dataloader etc. This silences that warning by taking the advice given.