### PR TITLE
Subclasses trainer to prevent memory leak.

### DIFF
--- a/udtube/cli.py
+++ b/udtube/cli.py
@@ -4,7 +4,7 @@ import logging
 
 from lightning.pytorch import cli
 
-from . import data, models
+from . import data, models, trainers
 
 
 class UDTubeCLI(cli.LightningCLI):
@@ -53,6 +53,9 @@ def main() -> None:
         models.UDTube,
         data.DataModule,
         auto_configure_optimizers=False,
+        # Prevents prediction logits from accumulating in memory; see the
+        # documentation in `trainers.py` for more context.
+        trainer_class=trainers.Trainer,
     )
 
 

--- a/udtube/trainers.py
+++ b/udtube/trainers.py
@@ -1,0 +1,19 @@
+"""Subclasses the trainer to prevent a memory leak in prediction.
+
+The trainer's `predict` method is called with `return_predictions=True`.
+Unexpectedly, this not only returns the prediction logits for each batch, but
+also appends them to an ever-growing list resident in CPU memory. When
+running prediction on a large file, this usually causes an out-of-memory crash.
+Therefore, we subclass the trainer to override this default and then use this
+as the trainer class in the CLI.
+"""
+
+from typing import Optional
+
+from lightning.pytorch import trainer
+
+
+class Trainer(trainer.Trainer):
+
+    def predict(self, *args, **kwargs):
+        return super().predict(*args, return_predictions=False, **kwargs)


### PR DESCRIPTION
Closes #46 .

Module docs explain some of the details. I wish there was a simpler solution.