### PR TITLE
Force-converts cells to string for serialization

### DIFF
--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -50,7 +50,7 @@ class TokenList:
             col_buf = []
             for key in _fieldnames:
                 col_buf.append(token.get(key, "_"))
-            line_buf.append("\t".join(col_buf))
+            line_buf.append("\t".join(str(cell) for cell in col_buf))
         return "\n".join(line_buf) + "\n"
 
     def __getitem__(self, index: int) -> Dict[str, str]:


### PR DESCRIPTION
I wasn't quite able to replicate #56:

* there's no issue with the `with` construct; I tested on Python 3.9-3.13.
* `from udtube import data` is valid at HEAD; it pulls in [this](https://github.com/CUNY-CL/udtube/blob/master/udtube/data/__init__.py)

However there is a minor issue: it uses an integral index whereas our CoNLL-U support keeps that as a string. (Arguably string is fine because we don't have to parse things like `1-4` into a tuple and have polymorphy.) 

I fix that trivially by force-casting things to `str` in `conllu.py`. This is probably free if the object is already a string, and this is not a "hot" part of the library anyways. This allows `pretokenize.py` to work again. 

Closes #56.