### PR TITLE
Sweep runs as subprocess

### DIFF
--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -47,7 +47,9 @@ def run_sweep(argv: List[str]) -> None:
         logging.error("Subprocess error: %s", error)
 
 
-def populate_config(config: Dict[str, Any], temp_config_handle: TextIO) -> None:
+def populate_config(
+    config: Dict[str, Any], temp_config_handle: TextIO
+) -> None:
     """Populates temporary configuration file.
 
     The wandb config data used here comes from the environment.


### PR DESCRIPTION
This modifies the sweep so that individual runs are all done in a subprocess. The reason for this is a belief that the OS will do a better job cleaning up memory (either on success or crash) than we can expect to happen even if we explicitly call the GC for Python and/or CUDA.