### PR TITLE
Pass subprocess return status to W&B using subprocess.Popen

### DIFF
--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -45,15 +45,11 @@ def run_sweep(argv: List[str]) -> None:
     process = subprocess.Popen(argv, stderr=subprocess.PIPE, text=True)
     # subprocess.Popen is nonblocking, so the while loop waits for
     # the subprocess to finish.
-    while True:
-        line = process.stderr.readline().rstrip()
-        logging.info(line)
+    while process.poll() is None:
+        logging.info(process.stderr.readline().rstrip())
         time.sleep(0.25)
-        if line == "" and process.poll() is not None:
-            break
     if process.returncode != 0:
         logging.error(f"Subprocess return code: {process.returncode}")
-
     wandb.finish(process.returncode)
 
 

--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -40,7 +40,7 @@ def run_sweep(argv: List[str]) -> int:
         argv: command-line arguments.
 
     Returns:
-        int: The exit code from the subprocess. 0 for success, non-zero for failure.
+        int: The exit code from the subprocess. 0 for success.
 
     We encapsulate each run by using a separate subprocess, which ought to
     ensure that memory is returned (etc.).
@@ -53,21 +53,21 @@ def run_sweep(argv: List[str]) -> int:
             line = process.stderr.readline()
             if line:
                 # Decode bytes and strip any trailing whitespace
-                error_msg = line.decode('utf-8').rstrip()
+                error_msg = line.decode("utf-8").rstrip()
                 if error_msg:  # Only log non-empty messages
                     logging.info(error_msg)
 
             # Check if process has finished
-            if line == b'' and process.poll() is not None:
+            if line == b"" and process.poll() is not None:
                 break
 
         if process.returncode != 0:
-            error_msg = f"Subprocess returned non-zero exit status {process.returncode}"
+            error_msg = f"Subprocess' exit status {process.returncode}"
             logging.error(error_msg)
 
         return process.returncode
 
-    except Exception as e:
+    except Exception:
         error_msg = f"Full traceback: {traceback.format_exc()}"
         logging.error(error_msg)
         return 1

--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -7,7 +7,6 @@ import logging
 import subprocess
 import sys
 import tempfile
-import time
 import traceback
 import warnings
 
@@ -43,14 +42,11 @@ def run_sweep(argv: List[str]) -> None:
     ensure that memory is returned (etc.).
     """
     process = subprocess.Popen(argv, stderr=subprocess.PIPE, text=True)
-    # subprocess.Popen is nonblocking, so the while loop waits for
-    # the subprocess to finish.
-    while process.poll() is None:
-        logging.info(process.stderr.readline().rstrip())
-        time.sleep(0.25)
-    if process.returncode != 0:
-        logging.error(f"Subprocess return code: {process.returncode}")
-    wandb.finish(process.returncode)
+    for line in process.stderr:
+        logging.info(line.rstrip())
+    return_code = process.wait()
+    logging.info(f"subprocess finished with return code: {return_code}")
+    wandb.finish(return_code)
 
 
 def populate_config(

--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -44,9 +44,7 @@ def run_sweep(argv: List[str]) -> None:
     process = subprocess.Popen(argv, stderr=subprocess.PIPE, text=True)
     for line in process.stderr:
         logging.info(line.rstrip())
-    return_code = process.wait()
-    logging.info(f"subprocess finished with return code: {return_code}")
-    wandb.finish(return_code)
+    wandb.finish(exit_code=process.wait())
 
 
 def populate_config(


### PR DESCRIPTION
- W&B should now almost always correctly display whether a run failed or was successful and also display relevant error information in the W&B log. 
- subprocess.Popen and subprocess.run were both considered. Although cleaner and simpler, subprocess.run often fails to capture the stack trace, so subprocess.Popen is a better option. 