### PR TITLE
Use simpler system for creating index dir

### DIFF
--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -153,10 +153,7 @@ class DataModule(lightning.LightningDataModule):
             ),
         )
         # Writes it to the model directory.
-        try:
-            os.mkdir(model_dir)
-        except FileExistsError:
-            pass
+        os.makedirs(model_dir, exist_ok=True)
         index.write(model_dir)
         return index
 


### PR DESCRIPTION
This can work recursively, so if model dir is `new/directory` it can create `new` if it doesn't already exist. (Currently this would fail.)