### PR TITLE
Uses the same idiom for writing lemmas

### DIFF
--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -76,10 +76,7 @@ class PredictionWriter(callbacks.BasePredictionWriter):
                     [token["form"] for token in tokenlist],
                     y_lemma_hat[i, :],
                 )
-                # `zip` should have already cut off the padding, so
-                # subscripting is not necessary here.
-                assert len(lemma_hat) == len(tokenlist)
-                for j, lemma in enumerate(lemma_hat):
+                for j, lemma in enumerate(lemma_hat[: len(tokenlist)]):
                     tokenlist[j]["lemma"] = lemma
             if y_feats_hat is not None:
                 feats_hat = self.mapper.decode_feats(y_feats_hat[i, :])


### PR DESCRIPTION
Running prediction over a huge amount of data, the assertion failed. (Tracking down the individual sentence that triggered this assertion would be quite difficult given the size of the data; it would take a day or more.)

While I wrote the comment there, I no longer remember what it means since I don't see an explicit `zip` here anymore.

I propose in interest of safety that we simply reuse the indexing idiom we use for the other heads and remove the assertion.