### PR TITLE
Cleaner decoding

### DIFF
--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -181,10 +181,7 @@ class DataModule(lightning.LightningDataModule):
         assert self.train is not None, "no train path"
         return data.DataLoader(
             self._conllu_map_dataset(self.train),
-            collate_fn=collators.Collator(
-                self.tokenizer,
-                self.index,
-            ),
+            collate_fn=collators.Collator(self.tokenizer),
             batch_size=self.batch_size,
             shuffle=True,
             num_workers=1,
@@ -195,10 +192,7 @@ class DataModule(lightning.LightningDataModule):
         assert self.train is not None, "no val path"
         return data.DataLoader(
             self._conllu_map_dataset(self.val),
-            collate_fn=collators.Collator(
-                self.tokenizer,
-                self.index,
-            ),
+            collate_fn=collators.Collator(self.tokenizer),
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
@@ -210,7 +204,7 @@ class DataModule(lightning.LightningDataModule):
         return data.DataLoader(
             # This one uses an iterative data loader instead.
             datasets.ConlluIterDataset(self.predict),
-            collate_fn=collators.Collator(self.tokenizer, self.index),
+            collate_fn=collators.Collator(self.tokenizer),
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
@@ -221,10 +215,7 @@ class DataModule(lightning.LightningDataModule):
         assert self.test is not None, "no test path"
         return data.DataLoader(
             self._conllu_map_dataset(self.test),
-            collate_fn=collators.Collator(
-                self.tokenizer,
-                self.index,
-            ),
+            collate_fn=collators.Collator(self.tokenizer),
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,

--- a/udtube/data/indexes.py
+++ b/udtube/data/indexes.py
@@ -29,7 +29,7 @@ class Vocabulary:
 
     def __init__(self, vocabulary: Iterable[str]):
         # TODO: consider storing this in-class for logging purposes.
-        self._index2symbol = special.SPECIALS + sorted(vocabulary)
+        self._index2symbol = special.SPECIAL + sorted(vocabulary)
         self._symbol2index = {c: i for i, c in enumerate(self._index2symbol)}
 
     def __len__(self) -> int:
@@ -58,24 +58,6 @@ class Vocabulary:
             str.
         """
         return self._index2symbol[index]
-
-    # Specials.
-
-    @property
-    def pad_idx(self) -> int:
-        return self._symbol2index[special.PAD]
-
-    @property
-    def unk_idx(self) -> int:
-        return self._symbol2index[special.UNK]
-
-    @property
-    def blank_idx(self) -> int:
-        return self._symbol2index[special.BLANK]
-
-    @property
-    def special_idx(self) -> Set[int]:
-        return {self.unk_idx, self.pad_idx, self.blank_idx}
 
 
 @dataclasses.dataclass

--- a/udtube/data/indexes.py
+++ b/udtube/data/indexes.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import pickle
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional
 
 from .. import defaults, special
 

--- a/udtube/data/indexes.py
+++ b/udtube/data/indexes.py
@@ -46,7 +46,7 @@ class Vocabulary:
         Returns:
             int.
         """
-        return self._symbol2index.get(lookup, self.unk_idx)
+        return self._symbol2index.get(lookup, special.UNK_IDX)
 
     def get_symbol(self, index: int) -> str:
         """Looks up symbol by index.

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -145,10 +145,9 @@ class Mapper:
         """
         symbols = []
         for idx in indices:
-            if idx == special.END_IDX:
+            if idx == special.PAD_IDX:
                 return symbols
-            elif not special.issymbol(idx):
-                symbols.append(vocabulary.get_symbol(idx))
+            symbols.append(vocabulary.get_symbol(idx))
         return symbols
 
     def decode_upos(self, indices: torch.Tensor) -> List[str]:

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -143,11 +143,13 @@ class Mapper:
         Yields:
             List[str]: decoded symbols.
         """
-        return [
-            vocabulary.get_symbol(c)
-            for c in indices
-            if c not in vocabulary.special_idx
-        ]
+        symbols = []
+        for idx in indices:
+            if idx == special.END_IDX:
+                return symbols
+            elif not special.issymbol(idx):
+                symbols.append(vocabulary.get_symbol(idx))
+        return symbols
 
     def decode_upos(self, indices: torch.Tensor) -> List[str]:
         """Decodes an upos tensor.

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -8,7 +8,7 @@ from typing import Iterable, List
 import torch
 
 from . import edit_scripts, indexes
-from .. import defaults
+from .. import defaults, special
 
 
 @dataclasses.dataclass

--- a/udtube/special.py
+++ b/udtube/special.py
@@ -8,15 +8,3 @@ SPECIAL = [PAD, UNK, BLANK]
 PAD_IDX = 0
 UNK_IDX = 1
 BLANK_IDX = 2
-
-
-def isspecial(idx: int) -> bool:
-    """Determines if a symbol is in the special range.
-
-    Args:
-        idx (int):
-
-    Returns:
-        bool.
-    """
-    return idx < len(SPECIAL)

--- a/udtube/special.py
+++ b/udtube/special.py
@@ -3,8 +3,20 @@
 PAD = "[PAD]"
 UNK = "[UNK]"
 BLANK = "_"
-SPECIALS = [PAD, UNK, BLANK]
+SPECIAL = [PAD, UNK, BLANK]
 
 PAD_IDX = 0
 UNK_IDX = 1
 BLANK_IDX = 2
+
+
+def isspecial(idx: int) -> bool:
+    """Determines if a symbol is in the special range.
+
+    Args:
+        idx (int):
+
+    Returns:
+        bool.
+    """
+    return idx < len(SPECIAL)


### PR DESCRIPTION
This proposed change adopts simplifications to decoding tensors into lists of strings (e.g., of tags or lemmas). We now "bail out" early on decoding tensors after we see the PAD symbol. This looks slightly elegant but is strictly faster. We can also delete some extra properties in the index class, and no longer need to pass the index to the collator.