### PR TITLE
Adds additional encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ version](https://badge.fury.io/py/udtube.svg)](https://pypi.org/project/udtube)
 versions](https://img.shields.io/pypi/pyversions/udtube.svg)](https://pypi.org/project/udtube)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/CUNY-CL/udtube/tree/master.svg?style=svg&circle-token=CCIPRJ_4V98VzpnERYSUaGFAkxu7v_70eea48ab82c8f19e4babbaa55a64855a80415bd)](https://dl.circleci.com/status-badge/redirect/gh/CUNY-CL/udtube/tree/master)
 
-
 UDTube is a neural morphological analyzer based on
 [PyTorch](https://pytorch.org/), [Lightning](https://lightning.ai/), and
 [Hugging Face transformers](https://huggingface.co/docs/transformers/en/index).

--- a/configs/README.md
+++ b/configs/README.md
@@ -14,7 +14,11 @@ Pre-trained encoders:
     (`google-bert/bert-base-cased`)](https://huggingface.co/google-bert/bert-base-cased)
 -   [mBERT
     (`google-bert/bert-base-multilingual-cased`)](https://huggingface.co/google-bert/bert-base-multilingual-cased)
--   [XLM-RoBERTa
-    (`FacebookAI/xlm-roberta-base`)](https://huggingface.co/FacebookAI/xlm-roberta-base)
+-   [DistillBERT
+    (`distilbert/distilbert-base-cased`)](https://huggingface.co/distilbert/distilbert-base-cased)
+-   [RoBERTa
+    (`FacebookAI/roberta-base`)](https://huggingface.co/FacebookAI/roberta-base)
 -   [RuBERT
     (`DeepPavlov/rubert-base-cased`)](https://huggingface.co/DeepPavlov/rubert-base-cased)
+-   [XLM-RoBERTa
+    (`FacebookAI/xlm-roberta-base`)](https://huggingface.co/FacebookAI/xlm-roberta-base)

--- a/configs/ewt_distillbert.yaml
+++ b/configs/ewt_distillbert.yaml
@@ -1,0 +1,60 @@
+seed_everything: 1995
+trainer:
+  max_epochs: 100
+  max_time: 00:06:00:00
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: epoch
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: val_loss
+        patience: 10
+        verbose: true
+  logger:
+    - class_path: lightning.pytorch.loggers.CSVLogger
+      init_args:
+        save_dir: /Users/Shinji/UD_English-EWT/models
+    - class_path: lightning.pytorch.loggers.WandbLogger
+      init_args:
+        project: unit1
+        save_dir: /Users/Shinji/UD_English-EWT/models
+model:
+  dropout: 0.4
+  encoder: distilbert/distilbert-base-cased
+  pooling_layers: 4
+  reverse_edits: true
+  use_upos: true
+  use_xpos: true
+  use_lemma: true
+  use_feats: true
+  encoder_optimizer:
+    class_path: torch.optim.Adam
+    init_args:
+      lr: 1e-6
+  encoder_scheduler:
+    class_path: udtube.schedulers.WarmupInverseSquareRoot
+    init_args:
+      warmup_epochs: 5
+  classifier_optimizer:
+    class_path: torch.optim.Adam
+    init_args:
+      lr: 1e-3
+  classifier_scheduler:
+    class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      monitor: val_loss
+      factor: 0.1
+data:
+  model_dir: /Users/Shinji/UD_English-EWT/models
+  train: /Users/Shinji/UD_English-EWT/en_ewt-ud-train.conllu
+  val: /Users/Shinji/UD_English-EWT/en_ewt-ud-dev.conllu
+  test: /Users/Shinji/UD_English-EWT/en_ewt-ud-test.conllu
+  predict: /Users/Shinji/UD_English-EWT/en_ewt-ud-test.conllu
+  batch_size: 32
+checkpoint:
+  filename: "model-{epoch:03d}-{val_loss:.4f}"
+  monitor: val_loss
+  verbose: true
+prediction:
+  path: /Users/Shinji/UD_English-EWT/predictions.conllu

--- a/configs/ewt_roberta.yaml
+++ b/configs/ewt_roberta.yaml
@@ -1,0 +1,60 @@
+seed_everything: 1995
+trainer:
+  max_epochs: 100
+  max_time: 00:06:00:00
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: epoch
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: val_loss
+        patience: 10
+        verbose: true
+  logger:
+    - class_path: lightning.pytorch.loggers.CSVLogger
+      init_args:
+        save_dir: /Users/Shinji/UD_English-EWT/models
+    - class_path: lightning.pytorch.loggers.WandbLogger
+      init_args:
+        project: unit1
+        save_dir: /Users/Shinji/UD_English-EWT/models
+model:
+  dropout: 0.4
+  encoder: FacebookAI/roberta-base
+  pooling_layers: 4
+  reverse_edits: true
+  use_upos: true
+  use_xpos: true
+  use_lemma: true
+  use_feats: true
+  encoder_optimizer:
+    class_path: torch.optim.Adam
+    init_args:
+      lr: 1e-6
+  encoder_scheduler:
+    class_path: udtube.schedulers.WarmupInverseSquareRoot
+    init_args:
+      warmup_epochs: 5
+  classifier_optimizer:
+    class_path: torch.optim.Adam
+    init_args:
+      lr: 1e-3
+  classifier_scheduler:
+    class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      monitor: val_loss
+      factor: 0.1
+data:
+  model_dir: /Users/Shinji/UD_English-EWT/models
+  train: /Users/Shinji/UD_English-EWT/en_ewt-ud-train.conllu
+  val: /Users/Shinji/UD_English-EWT/en_ewt-ud-dev.conllu
+  test: /Users/Shinji/UD_English-EWT/en_ewt-ud-test.conllu
+  predict: /Users/Shinji/UD_English-EWT/en_ewt-ud-test.conllu
+  batch_size: 32
+checkpoint:
+  filename: "model-{epoch:03d}-{val_loss:.4f}"
+  monitor: val_loss
+  verbose: true
+prediction:
+  path: /Users/Shinji/UD_English-EWT/predictions.conllu

--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -89,7 +89,11 @@ class DataModule(lightning.LightningDataModule):
             else indexes.Index.read(model_dir)
         )
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-            encoder, clean_up_tokenization_spaces=False
+            encoder,
+            # These options are not available on all tokenizers but seem to be
+            # ignored so they can be passed in safely.
+            clean_up_tokenization_spaces=False,
+            add_prefix_space=True,
         )
 
     # Based on: https://universaldependencies.org/u/pos/index.html.

--- a/udtube/modules.py
+++ b/udtube/modules.py
@@ -37,7 +37,9 @@ class UDTubeEncoder(lightning.LightningModule):
     ):
         super().__init__()
         self.dropout_layer = nn.Dropout(dropout)
-        self.encoder = encoders.load(encoder, dropout)
+        # TODO: Any parameters referenced in the remappings in
+        # encoders.SUPPORTED_ENCODERS need to be passed as kwargs here.
+        self.encoder = encoders.load(encoder, dropout=dropout)
         self.pooling_layers = pooling_layers
 
     # Properties.
@@ -129,7 +131,7 @@ class UDTubeEncoder(lightning.LightningModule):
         max_length = self.encoder.config.max_position_embeddings
         if actual_length > max_length:
             logging.warning(
-                "Truncating sequence from %d to %d", actual_length, max_length
+                "Truncating sequence from %d to %d", actual_length, max_length,
             )
             batch.tokens.input_ids = batch.tokens.input_ids[:max_length]
             batch.tokens.attention_mask = batch.tokens.attention_mask[


### PR DESCRIPTION
* Rejiggers encoders.py's big dictionary to be more general.
* Adds support for DistillBERT and RoBERTA (the English one, not the multilingual XLM-RobERTA); the latter requires a special option to the tokenizer which other models ignore.
* Adds sample configs to play with this.