### PR TITLE
Uses callback hooks to control file handles

### DIFF
--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -34,7 +34,7 @@ class PredictionWriter(callbacks.BasePredictionWriter):
         self.path = path
         self.sink = sys.stdout
         assert model_dir, "no model_dir specified"
-        self.mapper = data.Mapper.read(self.model_dir)
+        self.mapper = data.Mapper.read(model_dir)
 
     # Required API.
 

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -38,9 +38,12 @@ class PredictionWriter(callbacks.BasePredictionWriter):
 
     # Required API.
 
-    def on_predict_start(self, trainer: trainer.Trainer, pl_module: lightning.LightningModule) -> None:
-        # Placing this here prevents the creation of an empty file just in case a prediction
-        # callback was specified but UDTube is not running in predict mode.
+    def on_predict_start(
+        self, trainer: trainer.Trainer, pl_module: lightning.LightningModule
+    ) -> None:
+        # Placing this here prevents the creation of an empty file in the case
+        # where a prediction callback was specified but UDTube is not running
+        # in predict mode.
         if self.path:
             self.sink = open(self.path, "w")
 
@@ -90,6 +93,8 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             print(tokenlist.serialize(), file=self.sink)
         self.sink.flush()
 
-    def on_predict_end(self, trainer: trainer.Trainer, pl_module: lightning.LightningModule) -> None:
+    def on_predict_end(
+        self, trainer: trainer.Trainer, pl_module: lightning.LightningModule
+    ) -> None:
         if self.sink is not sys.stdout:
             self.sink.close()


### PR DESCRIPTION
See #88 for discussion.

Here I am using the built-in hooks to control when prediction files are opened or closed and hopefully this, not the lifetime of the callback, is the right timing.