### PR TITLE
Checks for no enabled heads

### DIFF
--- a/tests/nohead_test.py
+++ b/tests/nohead_test.py
@@ -1,0 +1,22 @@
+"""Tests trying to create a UDTube model without any classification heads."""
+
+import unittest
+
+from udtube import models, modules
+
+
+class NoHeadTest(unittest.TestCase):
+
+    def test_no_head_raises_error(self):
+        with self.assertRaises(modules.Error):
+            # Uses all default parameters except the heads.
+            _ = models.UDTube(
+                use_upos=False,
+                use_xpos=False,
+                use_lemma=False,
+                use_feats=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/udtube/modules.py
+++ b/udtube/modules.py
@@ -197,7 +197,7 @@ class UDTubeClassifier(lightning.LightningModule):
         **kwargs,
     ):
         super().__init__()
-        if not (use_upos or use_xpos or use_lemma or use_feats):
+        if not any([use_upos, use_xpos, use_lemma, use_feats]):
             raise Error("No classification heads enabled")
         self.upos_head = (
             self._make_head(hidden_size, upos_out_size) if use_upos else None


### PR DESCRIPTION
If there are no heads enabled, the classifier module will now raise an error (instead of crashing at a later stage with a less informative error: it'll say something about the optimizer not knowing what to do with a Torch module with no parameters---presumably the classifier).

Also adds a light test to make sure this fires.