### PR TITLE
Ghost Token Bugfix

### DIFF
--- a/tests/testdata/badsentence.conllu
+++ b/tests/testdata/badsentence.conllu
@@ -1,0 +1,9 @@
+# sent_id = 603797
+# text = Hey Anthony, sure thing.
+1			NOUN	NN	Number=Sing	_	_	_	SpacesAfter=\n
+2	Hey	hey	PROPN	NNP	Number=Sing	_	_	_	_
+3	Anthony	Anthony	PROPN	NNP	Number=Sing	_	_	_	SpaceAfter=No
+4	,	,	PUNCT	,	_	_	_	_	_
+5	sure	sure	ADJ	JJ	Degree=Pos	_	_	_	_
+6	thing	thing	NOUN	NN	Number=Sing	_	_	_	SpaceAfter=No
+7	.	.	PUNCT	.	_	_	_	_	_

--- a/tests/udtube_test.py
+++ b/tests/udtube_test.py
@@ -123,48 +123,5 @@ class UDTubeTest(unittest.TestCase):
         self.assertNonEmptyFileExists(evaluated_path)
         self.assertFileIdentity(evaluated_path, expected_path)
 
-    def test_whitespace_token(self):
-        # Testing an edge case where there's a whitespace token in the sentence
-        pesky_sentence_conllu = "badsentence.conllu"
-        # keeping the test as minimal as possible
-        encoder = "distilbert/distilbert-base-uncased"
-        # train/eval/pred are the same, we are more concerned about the file
-        data_path = os.path.join(TESTDATA_DIR, pesky_sentence_conllu)
-        model_dir = os.path.join(self.tempdir.name, "models")
-        cli.udtube_python_interface(
-            [
-                "fit",
-                f"--config={CONFIG_PATH}",
-                f"--data.model_dir={model_dir}",
-                f"--data.train={data_path}",
-                f"--data.val={data_path}",
-                f"--model.encoder={encoder}",
-            ]
-        )
-        # Confirms a checkpoint was created.
-        checkpoint_path = (
-            f"{model_dir}/lightning_logs/version_0/checkpoints/last.ckpt"
-        )
-        self.assertNonEmptyFileExists(checkpoint_path)
-
-        predicted_path = os.path.join(
-            self.tempdir.name, "badsentence_predicted.conllu"
-        )
-        # Predicts on "expected" data.
-        cli.udtube_python_interface(
-            [
-                "predict",
-                f"--ckpt_path={checkpoint_path}",
-                f"--config={CONFIG_PATH}",
-                f"--data.model_dir={model_dir}",
-                f"--data.predict={data_path}",
-                f"--prediction.path={predicted_path}",
-                f"--model.encoder={encoder}",
-            ]
-        )
-        # There was a bug where this caused system exit before file writing
-        self.assertNonEmptyFileExists(predicted_path)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/udtube_test.py
+++ b/tests/udtube_test.py
@@ -123,5 +123,6 @@ class UDTubeTest(unittest.TestCase):
         self.assertNonEmptyFileExists(evaluated_path)
         self.assertFileIdentity(evaluated_path, expected_path)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/udtube_test.py
+++ b/tests/udtube_test.py
@@ -138,7 +138,7 @@ class UDTubeTest(unittest.TestCase):
                 f"--data.model_dir={model_dir}",
                 f"--data.train={data_path}",
                 f"--data.val={data_path}",
-                f"--model.encoder={encoder}"
+                f"--model.encoder={encoder}",
             ]
         )
         # Confirms a checkpoint was created.
@@ -148,7 +148,7 @@ class UDTubeTest(unittest.TestCase):
         self.assertNonEmptyFileExists(checkpoint_path)
 
         predicted_path = os.path.join(
-            self.tempdir.name, f"badsentence_predicted.conllu"
+            self.tempdir.name, "badsentence_predicted.conllu"
         )
         # Predicts on "expected" data.
         cli.udtube_python_interface(
@@ -159,7 +159,7 @@ class UDTubeTest(unittest.TestCase):
                 f"--data.model_dir={model_dir}",
                 f"--data.predict={data_path}",
                 f"--prediction.path={predicted_path}",
-                f"--model.encoder={encoder}"
+                f"--model.encoder={encoder}",
             ]
         )
         # There was a bug where this caused system exit before file writing

--- a/tests/white_space_test.py
+++ b/tests/white_space_test.py
@@ -45,7 +45,6 @@ class UDTubeTest(unittest.TestCase):
             f"{model_dir}/lightning_logs/version_0/checkpoints/last.ckpt"
         )
         self.assertNonEmptyFileExists(checkpoint_path)
-
         predicted_path = os.path.join(
             self.tempdir.name, "badsentence_predicted.conllu"
         )

--- a/tests/white_space_test.py
+++ b/tests/white_space_test.py
@@ -1,0 +1,69 @@
+"""Testing how the system works when there is a whitespace token."""
+
+import os
+import tempfile
+import unittest
+
+from udtube import cli
+
+# Directory the unit test is located in, relative to the working directory.
+DIR = os.path.relpath(os.path.dirname(__file__), os.getcwd())
+CONFIG_PATH = os.path.join(DIR, "testdata/udtube_config.yaml")
+TESTDATA_DIR = os.path.join(DIR, "testdata")
+
+
+class UDTubeTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory(prefix="udtube_test-")
+        self.assertNonEmptyFileExists(CONFIG_PATH)
+        self.encoder = "distilbert/distilbert-base-uncased"
+
+    def assertNonEmptyFileExists(self, path: str):
+        self.assertTrue(os.path.exists(path), msg=f"file {path} not found")
+        self.assertGreater(
+            os.stat(path).st_size, 0, msg="file {path} is empty"
+        )
+
+    def test_whitespace_token(self):
+        # Testing a case where there's a whitespace token in the sentence.
+        # Keeping the test as minimal as possible;
+        # train/eval/pred are the same, we are more concerned about the file.
+        data_path = os.path.join(TESTDATA_DIR, "badsentence.conllu")
+        model_dir = os.path.join(self.tempdir.name, "models")
+        cli.udtube_python_interface(
+            [
+                "fit",
+                f"--config={CONFIG_PATH}",
+                f"--data.model_dir={model_dir}",
+                f"--data.train={data_path}",
+                f"--data.val={data_path}",
+                f"--model.encoder={self.encoder}",
+            ]
+        )
+        # Confirms a checkpoint was created.
+        checkpoint_path = (
+            f"{model_dir}/lightning_logs/version_0/checkpoints/last.ckpt"
+        )
+        self.assertNonEmptyFileExists(checkpoint_path)
+
+        predicted_path = os.path.join(
+            self.tempdir.name, "badsentence_predicted.conllu"
+        )
+        # Predicts on "expected" data.
+        cli.udtube_python_interface(
+            [
+                "predict",
+                f"--ckpt_path={checkpoint_path}",
+                f"--config={CONFIG_PATH}",
+                f"--data.model_dir={model_dir}",
+                f"--data.predict={data_path}",
+                f"--prediction.path={predicted_path}",
+                f"--model.encoder={self.encoder}",
+            ]
+        )
+        # There was a bug where this caused system exit before file writing.
+        self.assertNonEmptyFileExists(predicted_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -1,5 +1,6 @@
 """Custom callbacks."""
 
+import logging
 import sys
 from typing import Iterator, Optional, Sequence, TextIO
 
@@ -111,7 +112,9 @@ class PredictionWriter(callbacks.BasePredictionWriter):
                 setattr(token, attr, next(tags))
             except StopIteration:
                 # this is needed, otherwise this error is caught in lightning and causes exit code 0...
-                return
+                logging.error(f"There is a mismatch in length between the tags and tokenlist. attr: {attr}\n"
+                              f" tokenlist: {tokenlist}")
+                continue
 
     def on_predict_end(
         self, trainer: trainer.Trainer, pl_module: lightning.LightningModule

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -111,10 +111,11 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             try:
                 setattr(token, attr, next(tags))
             except StopIteration:
-                # this is needed, otherwise this error is caught in lightning and causes exit code 0...
+                # this is needed, otherwise this error is caught in
+                # lightning and causes exit code 0...
                 logging.error(
-                    f"There is a mismatch in length between the tags and tokenlist. attr: {attr}\n"
-                    f" tokenlist: {tokenlist}"
+                    f"There is a mismatch in length between the tags "
+                    f"and tokenlist. attr: {attr}\n tokenlist: {tokenlist}"
                 )
                 continue
 

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -112,8 +112,10 @@ class PredictionWriter(callbacks.BasePredictionWriter):
                 setattr(token, attr, next(tags))
             except StopIteration:
                 # this is needed, otherwise this error is caught in lightning and causes exit code 0...
-                logging.error(f"There is a mismatch in length between the tags and tokenlist. attr: {attr}\n"
-                              f" tokenlist: {tokenlist}")
+                logging.error(
+                    f"There is a mismatch in length between the tags and tokenlist. attr: {attr}\n"
+                    f" tokenlist: {tokenlist}"
+                )
                 continue
 
     def on_predict_end(

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -113,9 +113,8 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             except StopIteration:
                 # Prevents the error from being caught by Lightning.
                 logging.error(
-                    "Length mismatch between the tags and the "
-                    f"tokenlist for tags ({attr}).\n"
-                    f"Tokenlist sent id: {tokenlist.metadata.get('sent_id')}."
+                    f"Length mismatch for tag ({attr!r}) (sent_id, "
+                    f"if present): {tokenlist.metadata.get('sent_id')}"
                 )
                 continue
 

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -101,13 +101,17 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             attr (str): attribute on tokens where the tags should be inserted.
             tags (Iterator[str]): tags to insert.
         """
-        # Note that in when MWEs are present, the iterators with predicted tags
+        # Note that when MWEs are present, the iterators with predicted tags
         # from the classifier heads are shorter than the tokenlists, so we
         # `continue` without advancing said iterators.
         for token in tokenlist:
             if token.is_mwe:
                 continue
-            setattr(token, attr, next(tags))
+            try:
+                setattr(token, attr, next(tags))
+            except StopIteration:
+                # this is needed, otherwise this error is caught in lightning and causes exit code 0...
+                return
 
     def on_predict_end(
         self, trainer: trainer.Trainer, pl_module: lightning.LightningModule

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -114,7 +114,8 @@ class PredictionWriter(callbacks.BasePredictionWriter):
                 # Prevents the error from being caught by Lightning.
                 logging.error(
                     "Length mismatch between the tags and the "
-                    f"tokenlist ({len(tokenlist)})."
+                    f"tokenlist for tags ({attr}).\n"
+                    f"Tokenlist sent id: {tokenlist.metadata.get('sent_id')}."
                 )
                 continue
 

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -113,7 +113,7 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             except StopIteration:
                 # Prevents the error from being caught by Lightning.
                 logging.error(
-                    "Length mismatch between the tags and the 
+                    "Length mismatch between the tags and the "
                     f"tokenlist ({len(tokenlist)})."
                 )
                 continue

--- a/udtube/callbacks.py
+++ b/udtube/callbacks.py
@@ -111,11 +111,10 @@ class PredictionWriter(callbacks.BasePredictionWriter):
             try:
                 setattr(token, attr, next(tags))
             except StopIteration:
-                # this is needed, otherwise this error is caught in
-                # lightning and causes exit code 0...
+                # Prevents the error from being caught by Lightning.
                 logging.error(
-                    f"There is a mismatch in length between the tags "
-                    f"and tokenlist. attr: {attr}\n tokenlist: {tokenlist}"
+                    "Length mismatch between the tags and the 
+                    f"tokenlist ({len(tokenlist)})."
                 )
                 continue
 

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -186,7 +186,7 @@ class TokenList(collections.UserList):
     @staticmethod
     def _handle_whitespace_token(token: str) -> str:
         if re.search(r"^\s$", token, flags=re.MULTILINE):
-            # With BERT, white space "words" do not map back to a token index.
+            # Some tokenizers don't map whitespace tokens to a token index.
             # UNK is thus substituted.
             return special.UNK
         return token

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -186,9 +186,8 @@ class TokenList(collections.UserList):
     @staticmethod
     def _handle_whitespace_token(token: str) -> str:
         if re.search(r"^\s$", token, flags=re.MULTILINE):
-            # We noticed a behavior with BERT that the form feed, \f does not
-            # map back to a token index & this extends to all white spaces &
-            # affects length of the sequences, to avoid that, we will use UNK
+            # With BERT, form feed `\f` does not map back to a token index. 
+            # UNK is thus substituted.
             return special.UNK
         return token
 

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -185,10 +185,10 @@ class TokenList(collections.UserList):
 
     @staticmethod
     def _handle_whitespace_token(token: str) -> str:
-        if re.search("^\s$", token, flags=re.MULTILINE):
-            # We noticed a behavior with BERT that the form feed, \f does not map back to a token index
-            # (this extends to all white spaces) and messes with the length of the sequences,
-            # which is problematic downstream and causes unexpected errors, so to avoid that, we will use UNK
+        if re.search(r"^\s$", token, flags=re.MULTILINE):
+            # We noticed a behavior with BERT that the form feed, \f does not
+            # map back to a token index & this extends to all white spaces &
+            # affects length of the sequences, to avoid that, we will use UNK
             return special.UNK
         return token
 

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -194,7 +194,11 @@ class TokenList(collections.UserList):
 
     def get_tokens(self) -> List[str]:
         """List of tokens to be fed into tokenizer."""
-        return [self._handle_whitespace_token(token.form) for token in self if not token.is_mwe]
+        return [
+            self._handle_whitespace_token(token.form)
+            for token in self
+            if not token.is_mwe
+        ]
 
 
 # Parsing.

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -186,7 +186,7 @@ class TokenList(collections.UserList):
     @staticmethod
     def _handle_whitespace_token(token: str) -> str:
         if re.search(r"^\s$", token, flags=re.MULTILINE):
-            # With BERT, form feed `\f` does not map back to a token index. 
+            # With BERT, white space "words" do not map back to a token index.
             # UNK is thus substituted.
             return special.UNK
         return token

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -148,11 +148,9 @@ class Mapper:
                 indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
             )
             if idx == special.PAD_IDX and next_idx == special.PAD_IDX:
-                # We need some tolerance for misclassifying as padding,
-                # otherwise, this causes issues down the line
-                # TODO I think this can cheat metrics accidentally.
-                # This return affects _fill_in_tags,
-                # and if _fill_in_tags fails it seems we keep the default tags
+                # Returning here causes `_fill_in_tags` to use the keep the
+                # default tags.
+                # TODO: This can lead to cheating the metrics.
                 return
             yield vocabulary.get_symbol(idx)
 

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -145,8 +145,8 @@ class Mapper:
         """
         for idx in indices:
             if idx == special.PAD_IDX:
-                # To avoid sequence length mismatches
-                # _ is yielded for anything classified as a pad
+                # To avoid sequence length mismatches,
+                # _ is yielded for anything classified as a pad.
                 yield "_"
             else:
                 yield vocabulary.get_symbol(idx)

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -144,15 +144,12 @@ class Mapper:
             str: decoded symbols.
         """
         for i, idx in enumerate(indices):
-            next_idx = (
-                indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
-            )
-            if idx == special.PAD_IDX and next_idx == special.PAD_IDX:
-                # Returning here causes `_fill_in_tags` to use the keep the
-                # default tags.
-                # TODO: This can lead to cheating the metrics.
-                return
-            yield vocabulary.get_symbol(idx)
+            if idx == special.PAD_IDX:
+                # To avoid sequence length mismatches
+                # _ is yielded for anything classified as a pad
+                yield "_"
+            else:
+                yield vocabulary.get_symbol(idx)
 
     def decode_upos(self, indices: torch.Tensor) -> Iterator[str]:
         """Decodes an upos tensor.

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -144,7 +144,9 @@ class Mapper:
             str: decoded symbols.
         """
         for i, idx in enumerate(indices):
-            next_idx = indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
+            next_idx = (
+                indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
+            )
             if idx == special.PAD_IDX and next_idx == special.PAD_IDX:
                 # We need some tolerance for misclassifying as padding, otherwise, this causes issues down the line
                 # TODO I think this can cheat metrics accidentally. This return affects _fill_in_tags,

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -143,8 +143,12 @@ class Mapper:
         Yields:
             str: decoded symbols.
         """
-        for idx in indices:
-            if idx == special.PAD_IDX:
+        for i, idx in enumerate(indices):
+            next_idx = indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
+            if idx == special.PAD_IDX and next_idx == special.PAD_IDX:
+                # We need some tolerance for misclassifying as padding, otherwise, this causes issues down the line
+                # TODO I think this can cheat metrics accidentally. This return affects _fill_in_tags,
+                # TODO cont. and if _fill_in_tags fails it seems we keep the default tags
                 return
             yield vocabulary.get_symbol(idx)
 

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -148,9 +148,11 @@ class Mapper:
                 indices[i + 1] if i < len(indices) - 1 else special.PAD_IDX
             )
             if idx == special.PAD_IDX and next_idx == special.PAD_IDX:
-                # We need some tolerance for misclassifying as padding, otherwise, this causes issues down the line
-                # TODO I think this can cheat metrics accidentally. This return affects _fill_in_tags,
-                # TODO cont. and if _fill_in_tags fails it seems we keep the default tags
+                # We need some tolerance for misclassifying as padding,
+                # otherwise, this causes issues down the line
+                # TODO I think this can cheat metrics accidentally.
+                # This return affects _fill_in_tags,
+                # and if _fill_in_tags fails it seems we keep the default tags
                 return
             yield vocabulary.get_symbol(idx)
 

--- a/udtube/data/mappers.py
+++ b/udtube/data/mappers.py
@@ -143,7 +143,7 @@ class Mapper:
         Yields:
             str: decoded symbols.
         """
-        for i, idx in enumerate(indices):
+        for idx in indices:
             if idx == special.PAD_IDX:
                 # To avoid sequence length mismatches
                 # _ is yielded for anything classified as a pad


### PR DESCRIPTION
# Overview
Fixes #96 , hopefully. Tested on the minimal example.

# Breakdown
The primary issue was a sequence length mismatch that stemmed from two unfortunate conditions. 

1. Some whitespaces (namely form feed characters) enjoy token status in our tokenized dataset
2. The BERT tokenizer does not assign an ID to whitespace only characters

Minimal example for claim 2:
```
words = "\f"
batch = tokenizer.encode(words, return_tensors="pt", add_special_tokens=False)

print(batch)

>>> tensor([], size=(1, 0))
```

This led to issues with passing a sequence of tokens that is shorter than what is in the file, and this caused a slew of downstream errors. 

There is also two drivebys one on label `_decode`, which uncovered a possibly deeper issue and another on an unprotected `next()` in `callbacks.py`