### PR TITLE
Pooling layer efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The following YAML snippet shows the default architectural arguments.
     model:
       dropout: 0.5
       encoder: google-bert/bert-base-multilingual-cased
-      pooling_layers: 4
+      pooling_layers: 1
       reverse_edits: true
       use_upos: true
       use_xpos: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "udtube"
-version = "0.1.11"
+version = "0.1.12"
 description = "Neural morphological analysis"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/testdata/regenerate
+++ b/tests/testdata/regenerate
@@ -20,6 +20,7 @@ en() {
         --data.predict=tests/testdata/en_train.conllu \
         --model.encoder=google-bert/bert-base-cased \
         --model.use_xpos=True \
+        --trainer.enable_progress_bar=False \
         > tests/testdata/en_expected.conllu 
     udtube test \
         --ckpt_path="${MODEL_DIR}/lightning_logs/version_0/checkpoints/last.ckpt" \
@@ -28,6 +29,7 @@ en() {
         --data.test=tests/testdata/en_train.conllu \
         --model.encoder=google-bert/bert-base-cased \
         --model.use_xpos=True \
+        --trainer.enable_progress_bar=False \
         > tests/testdata/en_expected.test
     rm -rf "${MODEL_DIR}"
 }
@@ -48,6 +50,7 @@ ru() {
         --data.predict=tests/testdata/ru_train.conllu \
         --model.encoder=DeepPavlov/rubert-base-cased \
         --model.use_xpos=False \
+        --trainer.enable_progress_bar=False \
         > tests/testdata/ru_expected.conllu 
     udtube test \
         --ckpt_path="${MODEL_DIR}/lightning_logs/version_0/checkpoints/last.ckpt" \
@@ -56,6 +59,7 @@ ru() {
         --data.test=tests/testdata/ru_train.conllu \
         --model.encoder=DeepPavlov/rubert-base-cased \
         --model.use_xpos=False \
+        --trainer.enable_progress_bar=False \
         > tests/testdata/ru_expected.test 
     rm -rf "${MODEL_DIR}"
 }

--- a/tests/testdata/regenerate
+++ b/tests/testdata/regenerate
@@ -12,14 +12,14 @@ en() {
         --data.train=tests/testdata/en_train.conllu \
         --data.val=tests/testdata/en_train.conllu \
         --model.encoder=google-bert/bert-base-cased \
-        --model.use_xpos=True
+        --model.use_xpos=true
     udtube predict \
         --ckpt_path="${MODEL_DIR}/lightning_logs/version_0/checkpoints/last.ckpt" \
         --config=tests/testdata/udtube_config.yaml \
         --data.model_dir="${MODEL_DIR}" \
         --data.predict=tests/testdata/en_train.conllu \
         --model.encoder=google-bert/bert-base-cased \
-        --model.use_xpos=True \
+        --model.use_xpos=true \
         --trainer.enable_progress_bar=False \
         > tests/testdata/en_expected.conllu 
     udtube test \
@@ -28,8 +28,8 @@ en() {
         --data.model_dir="${MODEL_DIR}" \
         --data.test=tests/testdata/en_train.conllu \
         --model.encoder=google-bert/bert-base-cased \
-        --model.use_xpos=True \
-        --trainer.enable_progress_bar=False \
+        --model.use_xpos=true \
+        --trainer.enable_progress_bar=false \
         > tests/testdata/en_expected.test
     rm -rf "${MODEL_DIR}"
 }
@@ -59,7 +59,7 @@ ru() {
         --data.test=tests/testdata/ru_train.conllu \
         --model.encoder=DeepPavlov/rubert-base-cased \
         --model.use_xpos=False \
-        --trainer.enable_progress_bar=False \
+        --trainer.enable_progress_bar=false \
         > tests/testdata/ru_expected.test 
     rm -rf "${MODEL_DIR}"
 }

--- a/udtube/cli.py
+++ b/udtube/cli.py
@@ -32,6 +32,10 @@ class UDTubeCLI(cli.LightningCLI):
             "data.model_dir", "trainer.logger.init_args.save_dir"
         )
         parser.link_arguments("model.reverse_edits", "data.reverse_edits")
+        parser.link_arguments("model.use_upos", "data.use_upos")
+        parser.link_arguments("model.use_xpos", "data.use_xpos")
+        parser.link_arguments("model.use_lemma", "data.use_lemma")
+        parser.link_arguments("model.use_feats", "data.use_feats")
         parser.link_arguments(
             "data.upos_tagset_size",
             "model.upos_out_size",

--- a/udtube/data/conllu.py
+++ b/udtube/data/conllu.py
@@ -1,7 +1,8 @@
 """CoNLL-U file parser.
 
 This is roughly compatible with the third-party package `conllu`, though it
-only has features we care about."""
+only has features we care about.
+"""
 
 from __future__ import annotations
 

--- a/udtube/data/datamodules.py
+++ b/udtube/data/datamodules.py
@@ -167,13 +167,14 @@ class DataModule(lightning.LightningDataModule):
             )
         if self.use_lemma:
             logging.info(
-                "Lemma vocabulary (%d): [omitted]",
+                "Lemma vocabulary (%d): [omitted; not human-readable]",
                 self.lemma_tagset_size,
             )
         if self.use_feats:
             logging.info(
-                "Features vocabulary (%d): [omitted]",
+                "Features vocabulary (%d): %s",
                 self.feats_tagset_size,
+                self.pprint(self.index.feats),
             )
 
     # Properties.

--- a/udtube/data/indexes.py
+++ b/udtube/data/indexes.py
@@ -10,7 +10,8 @@ we could share a vocabulary or an embedding across classifier layers.
 
 Because of this, we also have the Index class, which holds instances of
 the lower-level vocabularies, one for each enabled classifier head, and which
-handles (de)serialization."""
+handles (de)serialization.
+"""
 
 from __future__ import annotations
 
@@ -28,7 +29,6 @@ class Vocabulary:
     _symbol2index: Dict[str, int]
 
     def __init__(self, vocabulary: Iterable[str]):
-        # TODO: consider storing this in-class for logging purposes.
         self._index2symbol = special.SPECIAL + sorted(vocabulary)
         self._symbol2index = {c: i for i, c in enumerate(self._index2symbol)}
 

--- a/udtube/defaults.py
+++ b/udtube/defaults.py
@@ -7,7 +7,7 @@ ENCODING = "utf-8"
 
 # Architecture arguments.
 ENCODER = "google-bert/bert-base-multilingual-cased"
-POOLING_LAYERS = 4
+POOLING_LAYERS = 1
 REVERSE_EDITS = True
 USE_UPOS = True
 USE_XPOS = True

--- a/udtube/modules.py
+++ b/udtube/modules.py
@@ -69,15 +69,19 @@ class UDTubeEncoder(lightning.LightningModule):
             A contextual word-level encoding.
         """
         # We move these manually.
-        x = self.encoder(
+        output = self.encoder(
             batch.input_ids.to(self.device),
             batch.attention_mask.to(self.device),
-        ).hidden_states
-        # Stacks the pooling layers.
-        x = torch.stack(x[-self.pooling_layers :])
-        # Averages them into one embedding layer; automatically squeezes the
-        # mean dimension.
-        x = torch.mean(x, dim=0)
+            output_hidden_states=self.pooling_layers > 1,
+        )
+        if self.pooling_layers == 1:
+            # Special case for just using the last layer's hidden states.
+            x = output.last_hidden_state
+        else:
+            # Mean-pools the last n layers' hidden states.
+            x = torch.stack(output.hidden_states[-self.pooling_layers :]).mean(
+                dim=0
+            )
         # Applies dropout.
         x = self.dropout_layer(x)
         # Maps from subword embeddings to word-level embeddings.
@@ -138,7 +142,7 @@ class UDTubeEncoder(lightning.LightningModule):
         return torch.stack(
             [
                 nn.functional.pad(
-                    sentence_embedding.T,
+                    sentence_embedding.mT,
                     (0, pad_max - len(sentence_embedding)),
                     value=0,
                 )

--- a/udtube/special.py
+++ b/udtube/special.py
@@ -2,9 +2,7 @@
 
 PAD = "[PAD]"
 UNK = "[UNK]"
-BLANK = "_"
-SPECIAL = [PAD, UNK, BLANK]
+SPECIAL = [PAD, UNK]
 
 PAD_IDX = 0
 UNK_IDX = 1
-BLANK_IDX = 2


### PR DESCRIPTION
Special cases `pooling_layers=1` to use `last_hidden_state` directly, avoiding unnecessary allocation of all hidden states. This seems to save a lot of GPU memory in my laptop experiments, and works well so I made it the default.

A few drive-bys:

1. suppress progress bar during test data generation.
2. add "not human-readable" to "[omitted]" when logging lemmas to explain why I omit them.
3. actually log features; why not?
4. pass information about which heads to build to the data module too, so it doesn't log vocabularies of heads not used.
5. removes _ from "special", since it doesn't require any special treatment in actuality; it's just another tag as far as we're concerned.
6. standardizes trailing `"""`: it's on its own line if the comment is more than one line.
7. uses `.mT` instead of `.T` to silence a warning from the future.